### PR TITLE
Revert my last pr

### DIFF
--- a/FluentCalculator.py
+++ b/FluentCalculator.py
@@ -52,15 +52,6 @@ def square():
         tex_input.set("Error")
         operator=""
 
-# Themefix
-btnwidth = 76
-zerowidth = btnwidth*2+2
-btnheight = 53
-row1x = 4
-row2x = 82
-row3x = 160
-row4x = 238
-
 root=tk.Tk()
 root.resizable(False, False)
 root.geometry('318x480')
@@ -72,13 +63,6 @@ if darkdetect.theme() == "Dark":
     sv_ttk.set_theme("dark")
     ntkutils.dark_title_bar(root)
     ntkutils.blur_window_background(root)
-    btnwidth = 74
-    zerowidth = btnwidth*2+4
-    btnheight = 51
-    row1x = 5
-    row2x = 83
-    row3x = 161
-    row4x = 239
 else:
     sv_ttk.set_theme("light")
     ntkutils.blur_window_background(root)    
@@ -91,31 +75,31 @@ txtDisplay = Label(root, textvariable=tex_input, font=('Segoe UI Variable Displa
 txtDisplay2 =Label(root,textvariable=tex_input2, font=('Segoe UI Variable Display Semibold','15'),anchor="e",width=11, fg='#707476').place(x=162,y=30)
 
 always_on_top = BooleanVar()
-alwaysontop=ttk.Checkbutton(root, text="", variable = always_on_top,onvalue=1, offvalue=0, style="Toggle.TButton",command=lambda:aot()).place(x=row1x, y= 148, height=btnheight, width=btnwidth)
-btnsquare=ttk.Button(root, text="x²", command=lambda:square()).place(x=row1x, y= 203, height=btnheight, width=btnwidth)
-btn7=ttk.Button(root, text="7", command=lambda:btnClick(7)).place(x=row1x, y= 258, height=btnheight, width=btnwidth)
-btn4=ttk.Button(root, text="4", command=lambda:btnClick(4)).place(x=row1x, y= 313, height=btnheight, width=btnwidth)
-btn1=ttk.Button(root, text="1", command=lambda:btnClick(1)).place(x=row1x, y= 368, height=btnheight, width=btnwidth)
+alwaysontop=ttk.Checkbutton(root, text="", variable = always_on_top,onvalue=1, offvalue=0, style="Toggle.TButton",command=lambda:aot()).place(x=4, y=148, height=53, width=76)
+btnsquare=ttk.Button(root, text="x²", command=lambda:square()).place(x=4, y=203, height=53, width=76)
+btn7=ttk.Button(root, text="7", command=lambda:btnClick(7)).place(x=4, y=258, height=53, width=76)
+btn4=ttk.Button(root, text="4", command=lambda:btnClick(4)).place(x=4, y=313, height=53, width=76)
+btn1=ttk.Button(root, text="1", command=lambda:btnClick(1)).place(x=4, y=368, height=53, width=76)
 
-openbtn=ttk.Button(root, text="(", command=lambda:btnClick('(')).place(x=row2x, y= 148, height=btnheight, width=btnwidth)
-btnClear=ttk.Button(root, text="C", command=btnClearDisplay).place(x=row2x, y= 203, height=btnheight, width=btnwidth)
-btn8=ttk.Button(root, text="8", command=lambda:btnClick(8)).place(x=row2x, y= 258, height=btnheight, width=btnwidth)
-btn5=ttk.Button(root, text="5", command=lambda:btnClick(5)).place(x=row2x, y= 313, height=btnheight, width=btnwidth)
-btn2=ttk.Button(root, text="2", command=lambda:btnClick(2)).place(x=row2x, y= 368, height=btnheight, width=btnwidth)
-btn0=ttk.Button(root, text="0", command=lambda:btnClick(0)).place(x=row1x, y= 423, height=btnheight, width=zerowidth)
+openbtn=ttk.Button(root, text="(", command=lambda:btnClick('(')).place(x=82, y=148, height=53, width=76)
+btnClear=ttk.Button(root, text="C", command=btnClearDisplay).place(x=82, y= 203, height=53, width=76)
+btn8=ttk.Button(root, text="8", command=lambda:btnClick(8)).place(x=82, y=258, height=53, width=76)
+btn5=ttk.Button(root, text="5", command=lambda:btnClick(5)).place(x=82, y=313, height=53, width=76)
+btn2=ttk.Button(root, text="2", command=lambda:btnClick(2)).place(x=82, y=368, height=53, width=76)
+btn0=ttk.Button(root, text="0", command=lambda:btnClick(0)).place(x=4, y=423, height=53, width=154)
 
-closebtn=ttk.Button(root, text=")", command=lambda:btnClick(')')).place(x=row3x, y= 148, height=btnheight, width=btnwidth)
-Backspace = ttk.Button(root, text='', command=backspace).place(x=row3x, y= 203, height=btnheight, width=btnwidth)
-btn9=ttk.Button(root, text="9", command=lambda:btnClick(9)).place(x=row3x, y= 258, height=btnheight, width=btnwidth)
-btn6=ttk.Button(root, text="6", command=lambda:btnClick(6)).place(x=row3x, y= 313, height=btnheight, width=btnwidth)
-btn3=ttk.Button(root, text="3", command=lambda:btnClick(3)).place(x=row3x, y= 368, height=btnheight, width=btnwidth)
-btndot=ttk.Button(root, text=".", command=lambda:btnClick('.')).place(x=row3x, y= 423, height=btnheight, width=btnwidth)
+closebtn=ttk.Button(root, text=")", command=lambda:btnClick(')')).place(x=160, y=148, height=53, width=76)
+Backspace = ttk.Button(root, text='', command=backspace).place(x=160, y=203, height=53, width=76)
+btn9=ttk.Button(root, text="9", command=lambda:btnClick(9)).place(x=160, y=258, height=53, width=76)
+btn6=ttk.Button(root, text="6", command=lambda:btnClick(6)).place(x=160, y=313, height=53, width=76)
+btn3=ttk.Button(root, text="3", command=lambda:btnClick(3)).place(x=160, y=368, height=53, width=76)
+btndot=ttk.Button(root, text=".", command=lambda:btnClick('.')).place(x=160, y=423, height=53, width=76)
 
-Divsion=ttk.Button(root, text="", command=lambda:btnClick("/")).place(x=row4x, y= 148, height=btnheight, width=btnwidth)
-Multiple=ttk.Button(root, text="", command=lambda:btnClick("*")).place(x=row4x, y= 203, height=btnheight, width=btnwidth)
-Subtraction=ttk.Button(root, text="", command=lambda:btnClick("-")).place(x=row4x, y= 258, height=btnheight, width=btnwidth)
-Addition=ttk.Button(root, text="",  command=lambda:btnClick("+")).place(x=row4x, y= 313, height=btnheight, width=btnwidth)
-equal=ttk.Button(root, text="", command=btnEqualsInput).place(x=row4x, y= 368, height=btnheight*2+2, width=btnwidth)
+Divsion=ttk.Button(root, text="", command=lambda:btnClick("/")).place(x=238, y=148, height=53, width=76)
+Multiple=ttk.Button(root, text="", command=lambda:btnClick("*")).place(x=238, y=203, height=53, width=76)
+Subtraction=ttk.Button(root, text="", command=lambda:btnClick("-")).place(x=238, y=258, height=53, width=76)
+Addition=ttk.Button(root, text="",  command=lambda:btnClick("+")).place(x=238, y=313, height=53, width=76)
+equal=ttk.Button(root, text="", command=btnEqualsInput).place(x=238, y=368, height=108, width=76)
 
 root.bind('<Return>', btnEqualsInput)
 root.bind('<BackSpace>', backspace)


### PR DESCRIPTION
Ok, so, i investigated in this topic a little bit further (I think you say it like that) and found out, that the buttons actually dont change position when dark mode is enabled. The contrast between the border color of the white buttons and the white background is just so low, that they appear 1px smaller than they actually are, which is the reason that the dark buttons look like they are closer to each other. I will attach a video that shows this. Sorry for the inconvenience.

https://user-images.githubusercontent.com/83908932/163678536-d5cc54dc-d935-4850-9319-ade9ee2a0c15.mp4

